### PR TITLE
further C++ -ify, do more cleanup etc

### DIFF
--- a/include/blt/hook.hh
+++ b/include/blt/hook.hh
@@ -1,3 +1,5 @@
+#ifndef _HOOK_H
+#define _HOOK_H
 #pragma once
 
 #include <cstdlib>
@@ -25,34 +27,37 @@ namespace blt {
     } luaL_reg;
 
     /*
-     * Foreign function pointers
+     * Forward-declarations of our hooked functions
      */
 
-    extern void        (*lua_call)         (lua_state*, int, int);
-    extern int         (*lua_pcall)        (lua_state*, int, int, int);
-    extern int         (*lua_gettop)       (lua_state*);
-    extern void        (*lua_settop)       (lua_state*, int);
-    extern const char* (*lua_tolstring)    (lua_state*, int, size_t*);
-    extern int         (*luaL_loadfile)    (lua_state*, const char*);
-    extern int         (*lua_load)         (lua_state*, lua_reader*, void*, const char*);
-    extern void        (*lua_setfield)     (lua_state*, int, const char*);
-    extern void        (*lua_createtable)  (lua_state*, int, int);
-    extern void        (*lua_insert)       (lua_state*, int);
-    extern lua_state*  (*lua_newstate)     (lua_alloc, void*);
-    extern void        (*lua_close)        (lua_state*);
-    extern void        (*lua_rawset)       (lua_state*, int);
-    extern void        (*lua_settable)     (lua_state*, int);
-    extern void        (*lua_pushnumber)   (lua_state*, double);
-    extern void        (*lua_pushinteger)  (lua_state*, ptrdiff_t);
-    extern void        (*lua_pushboolean)  (lua_state*, bool);
-    extern void        (*lua_pushcclosure) (lua_state*, lua_cfunction, int);
-    extern void        (*lua_pushlstring)  (lua_state*, const char*, size_t);
-    extern void        (*luaI_openlib)     (lua_state*, const char*, const luaL_reg*, int);
-    extern void        (*luaL_ref)         (lua_state*, int);
-    extern void        (*lua_rawgeti)      (lua_state*, int, int);
-    extern void        (*luaL_unref)       (lua_state*, int, int);
-    extern void        (*do_game_update)   ();
-    extern int         (*luaL_newstate)    (char, char, int);
+extern "C" {
+    void        hlua_call         (lua_state*, int, int);
+    int         hlua_pcall        (lua_state*, int, int, int);
+    int         hlua_gettop       (lua_state*);
+    void        hlua_settop       (lua_state*, int);
+    const char* hlua_tolstring    (lua_state*, int, size_t*);
+    int         hluaL_loadfile    (lua_state*, const char*);
+    int         hlua_load         (lua_state*, lua_reader*, void*, const char*);
+    void        hlua_setfield     (lua_state*, int, const char*);
+    void        hlua_createtable  (lua_state*, int, int);
+    void        hlua_insert       (lua_state*, int);
+    lua_state*  hlua_newstate     (lua_alloc, void*);
+    void        hlua_close        (lua_state*);
+    void        hlua_rawset       (lua_state*, int);
+    void        hlua_settable     (lua_state*, int);
+    void        hlua_pushnumber   (lua_state*, double);
+    void        hlua_pushinteger  (lua_state*, ptrdiff_t);
+    void        hlua_pushboolean  (lua_state*, bool);
+    void        hlua_pushcclosure (lua_state*, lua_cfunction, int);
+    void        hlua_pushlstring  (lua_state*, const char*, size_t);
+    void        hluaI_openlib     (lua_state*, const char*, const luaL_reg*, int);
+    void        hluaL_ref         (lua_state*, int);
+    void        hluaL_openlib     (lua_state*, const char*, const luaL_reg*, int);
+    void        hlua_rawgeti      (lua_state*, int, int);
+    void        hluaL_unref       (lua_state*, int, int);
+    int         hluaL_newstate    (char, char, int);
+}
+    void        dslUpdateDetour   ();
 
     /*
      * Internal
@@ -61,3 +66,7 @@ namespace blt {
     void InitLUAHooks(void*);
 
 }
+
+/* vim: set ts=4 softtabstop=0 sw=4 expandtab: */
+
+#endif //_HOOK_H

--- a/src/blt_main.cc
+++ b/src/blt_main.cc
@@ -6,12 +6,13 @@
 #define _GNU_SOURCE
 #endif
 
-#include <unistd.h>
-#include <stdio.h>
+extern "C" {
 #include <dlfcn.h>
-#include <stdbool.h>
-
+}
+#include <iostream>
 #include <blt/hook.hh>
+
+using std::cerr;
 
 /*
  * Test for a GCC-compatible compiler, because we need 
@@ -37,7 +38,7 @@ static void
 blt_main ()
 {
     void* dlHandle = dlopen(NULL, RTLD_LAZY);
-    fprintf(stderr, "dlHandle = %p\n", dlHandle);
+    cerr << "dlHandle = " << dlHandle << "\n";
 
     /*
      * Hack: test for presence of a known unique function amongst the libraries loaded by payday 

--- a/src/hook.cc
+++ b/src/hook.cc
@@ -1,9 +1,10 @@
+extern "C" {
+#include <dlfcn.h>
+}
+#include <iostream>
 #include <subhook.h>
 #include <blt/hook.hh>
-#include <cstdio>
 #include <list>
-#include <dlfcn.h>
-#include <iostream>
 
 namespace blt {
 
@@ -11,31 +12,34 @@ namespace blt {
 
     std::list<lua_state*> activeStates;
 
-    void        (*lua_call)         (lua_state*, int, int);
-    int         (*lua_pcall)        (lua_state*, int, int, int);
-    int         (*lua_gettop)       (lua_state*);
-    void        (*lua_settop)       (lua_state*, int);
-    const char* (*lua_tolstring)    (lua_state*, int, size_t*);
-    int         (*luaL_loadfile)    (lua_state*, const char*);
-    int         (*lua_load)         (lua_state*, lua_reader*, void*, const char*);
-    void        (*lua_setfield)     (lua_state*, int, const char*);
-    void        (*lua_createtable)  (lua_state*, int, int);
-    void        (*lua_insert)       (lua_state*, int);
-    lua_state*  (*lua_newstate)     (lua_alloc, void*);
-    void        (*lua_close)        (lua_state*);
-    void        (*lua_rawset)       (lua_state*, int);
-    void        (*lua_settable)     (lua_state*, int);
-    void        (*lua_pushnumber)   (lua_state*, double);
-    void        (*lua_pushinteger)  (lua_state*, ptrdiff_t);
-    void        (*lua_pushboolean)  (lua_state*, bool);
-    void        (*lua_pushcclosure) (lua_state*, lua_cfunction, int);
-    void        (*lua_pushlstring)  (lua_state*, const char*, size_t);
-    void        (*luaL_openlib)     (lua_state*, const char*, const luaL_reg*, int);
-    void        (*luaL_ref)         (lua_state*, int);
-    void        (*lua_rawgeti)      (lua_state*, int, int);
-    void        (*luaL_unref)       (lua_state*, int, int);
+extern "C" {
+    void        (*olua_call)         (lua_state*, int, int);
+    int         (*olua_pcall)        (lua_state*, int, int, int);
+    int         (*olua_gettop)       (lua_state*);
+    void        (*olua_settop)       (lua_state*, int);
+    const char* (*olua_tolstring)    (lua_state*, int, size_t*);
+    int         (*oluaL_loadfile)    (lua_state*, const char*);
+    int         (*olua_load)         (lua_state*, lua_reader*, void*, const char*);
+    void        (*olua_setfield)     (lua_state*, int, const char*);
+    void        (*olua_createtable)  (lua_state*, int, int);
+    void        (*olua_insert)       (lua_state*, int);
+    lua_state*  (*olua_newstate)     (lua_alloc, void*);
+    void        (*olua_close)        (lua_state*);
+    void        (*olua_rawset)       (lua_state*, int);
+    void        (*olua_settable)     (lua_state*, int);
+    void        (*olua_pushnumber)   (lua_state*, double);
+    void        (*olua_pushinteger)  (lua_state*, ptrdiff_t);
+    void        (*olua_pushboolean)  (lua_state*, bool);
+    void        (*olua_pushcclosure) (lua_state*, lua_cfunction, int);
+    void        (*olua_pushlstring)  (lua_state*, const char*, size_t);
+    void        (*oluaL_openlib)     (lua_state*, const char*, const luaL_reg*, int);
+    void        (*oluaL_ref)         (lua_state*, int);
+    void        (*olua_rawgeti)      (lua_state*, int, int);
+    void        (*oluaL_unref)       (lua_state*, int, int);
+    int         (*oluaL_newstate)    (char, char, int);
+
     void        (*do_game_update)   ();
-    int         (*luaL_newstate)    (char, char, int);
+}
 
     /*
      * Internal
@@ -50,7 +54,7 @@ namespace blt {
     dslUpdateDetour()
     {
         SubHook::ScopedRemove remove(&gameUpdateDetour);
-        fprintf(stderr, "dsl::EventManager::update() detour called\n");
+        cerr << "dsl::EventManager::update() detour called\n";
 
         return do_game_update();
     }
@@ -61,9 +65,9 @@ namespace blt {
 #       define setcall(name) \
             ret = dlsym(dlHandle, #name); \
             cerr << #name << " = " << ret << "\n"; \
-            *(void **) (&name) = ret;
+            *(void **) (&o ## name) = ret;
 
-        fprintf(stderr, "setting up lua function access\n");
+        cerr << "setting up lua function access\n";
 
         {
             void* ret;
@@ -98,11 +102,12 @@ namespace blt {
             setcall(luaL_newstate);
         }
 
-        fprintf(stderr, "setting up intercepts\n");
-
-        {
-            gameUpdateDetour.Install((void *)do_game_update, (void *)dslUpdateDetour);
-        }
+// TODO: fix this!
+//        cerr << "setting up intercepts\n";
+//
+//        {
+//            gameUpdateDetour.Install((void *)do_game_update, (void *)dslUpdateDetour);
+//        }
 
 #       undef setcall
     }


### PR DESCRIPTION
 - made lua-stuff extern "C"
 - put header in #ifndef-#define-#endif sequence
 - made header use functions instead of function pointers
 - add modeline to header
 - use cerr instead of fprintf and remove all c-stdlib includes
 - disabled SubHook::Install for now

It now compiles and does not crash Payday *yay* -- but we cannot hook functions yet, it seems, without crashing Payday. Feel free to merge now or wait. I'll see whether I have more time for investigating these issues.